### PR TITLE
Test with unambiguous doubles.

### DIFF
--- a/R/files.R
+++ b/R/files.R
@@ -51,6 +51,7 @@ RemoveDirs <- function(dirs) {
 #' @param delim Delimeter used to separate values.
 #' @param out.name The path to the output file containing the merged tables.
 #' @param header Do the tables to be merged have headers?
+#' @param ... Additional arguments passed to [readr::read_delim]
 #' @examples
 #' setwd(tempdir())
 #' dir.create("MergeTablesOnDisk_test")
@@ -63,8 +64,8 @@ RemoveDirs <- function(dirs) {
 #' setwd("..")
 #' RemoveDirs("MergeTablesOnDisk_test")
 #' @export
-MergeTablesOnDisk <- function(file.names, delim, out.name, header = TRUE) {
-  tables <- lapply(file.names, readr::read_delim, delim, col_names = header)
+MergeTablesOnDisk <- function(file.names, delim, out.name, header = TRUE, ...) {
+  tables <- lapply(file.names, readr::read_delim, delim, col_names = header, ...)
   ncs <- vapply(tables, ncol, integer(1))
   if (!AllEqual(ncs)) stop("The tables have different numbers of columns.")
   if (header) {

--- a/man/MergeTablesOnDisk.Rd
+++ b/man/MergeTablesOnDisk.Rd
@@ -4,7 +4,7 @@
 \alias{MergeTablesOnDisk}
 \title{Merge Tables.}
 \usage{
-MergeTablesOnDisk(file.names, delim, out.name, header = TRUE)
+MergeTablesOnDisk(file.names, delim, out.name, header = TRUE, ...)
 }
 \arguments{
 \item{file.names}{The paths to the files to merge.}
@@ -14,6 +14,8 @@ MergeTablesOnDisk(file.names, delim, out.name, header = TRUE)
 \item{out.name}{The path to the output file containing the merged tables.}
 
 \item{header}{Do the tables to be merged have headers?}
+
+\item{...}{Additional arguments passed to \link[readr:read_delim]{readr::read_delim}}
 }
 \description{
 Merge tables saved on disk as delimited files. The merging is done lengthways

--- a/tests/testthat/test_files.R
+++ b/tests/testthat/test_files.R
@@ -71,16 +71,16 @@ test_that("MergeTablesOnDisk works", {
   setwd(tempdir())
   expect_true(dir.create("MergeTablesOnDisk_test"))
   setwd("MergeTablesOnDisk_test")
-  tab1 <- tibble::tibble(x = 1, y = 2)
-  tab2 <- tibble::tibble(x = 1, y = 29)
-  tab3 <- tibble::tibble(x = 1, z = 29)
-  tab4 <- tibble::tibble(x = 1, y = 29, z = 0)
+  tab1 <- tibble::tibble(x = 1.5, y = 2.5)
+  tab2 <- tibble::tibble(x = 1.5, y = 29.5)
+  tab3 <- tibble::tibble(x = 1.5, z = 29.5)
+  tab4 <- tibble::tibble(x = 1.5, y = 29.5, z = 0.5)
   mapply(readr::write_csv, list(tab1, tab2, tab3, tab4),
          paste0(c("tab1", "tab2", "tab3", "tab4"), ".csv"))
   expect_equal(MergeTablesOnDisk(c("tab1.csv", "tab2.csv"), ",", "merged.csv"),
-               tibble::tibble(x = c(1, 1), y = c(2, 29)))
+               tibble::tibble(x = c(1.5, 1.5), y = c(2.5, 29.5)))
   expect_equal(readr::read_csv("merged.csv"),
-               tibble::tibble(x = c(1, 1), y = c(2, 29)))
+               tibble::tibble(x = c(1.5, 1.5), y = c(2.5, 29.5)))
   expect_error(MergeTablesOnDisk(c("tab1.csv", "tab3.csv"), ",", "merged.csv"))
   expect_error(MergeTablesOnDisk(c("tab1.csv", "tab4.csv"), ",", "merged.csv"))
   setwd("..")


### PR DESCRIPTION
The next release of readr (1.1.0) modifies how numeric vectors
containing whole numbers are written by write_* functions. Previous
these numbers were written with a trailing `.0`, which ensures they were
always read as numerics as well.

This behavior was a change from R's typical output (which prints without
a trailing `.0`), so readr has been changed to do the same.

This change causes a test failure, as when the numbers are read back in
they are read as integers rather than numerics. Changing the test data
to use unambiguous double values fixes the issue.

This PR also adds a `...` argument to MergeTablesOnDisk, which allows
users to pass additional arguments to `readr::read_delim` if necessary
(such as supplying explicit column types).